### PR TITLE
Generate icons with custom path

### DIFF
--- a/generate-icons.js
+++ b/generate-icons.js
@@ -7,7 +7,7 @@ const path = require('path');
 // The generated components are based on the Bootstrap Icons URL, for example: https://icons.getbootstrap.com/icons/alarm-fill/
 // If the URL changes, then the components will not be generated correctly
 const iconsUrl = 'https://icons.getbootstrap.com/';
-const iconsPath = './icons/';
+let iconsPath = './icons/';
 
 function toPascalCase(str) {
   return str
@@ -75,13 +75,22 @@ async function generateIconComponent(icon) {
   const component = ejs.render(template, { iconName: iconComponentName, width: 16, height: 16, paths });
 
   // Write the component to a file
-  console.log(`Generating ${iconComponentName}...`);  
+  console.log(`Generating ${iconComponentName}...`);
   fs.writeFileSync(path.join(iconsPath, `${iconComponentName}.tsx`), component);
 }
 
 async function generateIcons() {
   const argIconNames = process.argv.slice(2);
   const icons = await fetchIconsList(argIconNames);
+
+  if (argIconNames.some(arg => arg.startsWith('--path='))) {
+    const strPathIndex = argIconNames.findIndex(arg => arg.startsWith('--path='));
+    const strPath = argIconNames[strPathIndex].substring('--path='.length);
+    const match = strPath.match(/(.+)/);
+    if (match) {
+      iconsPath = match[1];
+    }
+  }
 
   // If the iconsPath does not exist, then create it
   if (!fs.existsSync(iconsPath)) {


### PR DESCRIPTION
### Description
A functionality is added so that through the command line the path where the generated icons will be saved can be specified.

### Problem or Related Task
While working on my project, which required the icons to be executed in a specific path, the opportunity arose for the icon save path to be managed from the command line.

### Changes Made
The scope of the variable `iconsPath` is changed to `let`, as it is intended to be updated in case a new path comes from the command line.

Within the generateIcons function, a validation is added to determine if there is a string in the `argIconNames` array that starts with `--path=`. If this condition is `true`, the index where the match of the string starting with `--path=` is found is obtained. Then, the value of the path is obtained by substring starting from the length of `--path=`. Finally, the path is obtained, and the value of iconsPath is reassigned.

If it cannot be identified that a string starting with `--path=` exists in the array, the value of `iconsPath` remains with the default value.

### Tests Performed
(Describe the tests you have conducted to ensure your changes work as expected)

### Testing Steps
(Provide step-by-step instructions for the reviewer to test your changes)

1. Run the command 'node generate-icons.js cart3 --path=./test'.
2. Check that the icons are generated in the 'test' folder.

### Additional Notes
(Any other relevant information you want to add)